### PR TITLE
Correct an error in the longBlockString function

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -329,7 +329,7 @@ function longBlockString(
     output += `\n--- Verifier ${j}`;
     output += `\n---- ${uid.toString("hex")}`;
   });
-  output += `\n-- Backlinks (${block.verifiers.length}):`;
+  output += `\n-- Backlinks (${block.backlinks.length}):`;
   block.backlinks.forEach((value, j) => {
     output += `\n--- Backlink ${j}`;
     output += `\n---- ${value.toString("hex")}`;


### PR DESCRIPTION
Print the correct value of the numbers of backlinks